### PR TITLE
Adicionando pull-request read

### DIFF
--- a/.github/workflows/participacao.yml
+++ b/.github/workflows/participacao.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write     # necessário para publicar no branch gh-pages
   issues: read
+  pull-requests: read
   actions: write
 
 jobs:


### PR DESCRIPTION
O erro 403 Forbidden ocorre porque o token de autenticação (GITHUB_TOKEN) no GitHub Actions não tinha permissão explícita para ler pull requests #252 