### PR TITLE
Adicionando o Link do video de como utilizar no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,6 @@ https://youtu.be/vXIJ2t6O8QU?si=11NeaYQ7K9PGJ7cp
   $ pip install -r requirements.txt
   ```
 
-<br>
-
-4. Ativando o Database no seguinte diretório: `projetoDsTardeTurmaAB/backend/`, rode o comando abaixo:
-
-```cmd
-$ docker compose up
-``` 
 
 <br>
 


### PR DESCRIPTION
A pessoa responsavel por isso nao estava conseguindo atualizar o Readme, foi adicionado o link do video dele agora.

Tambem foi retirado as instruções de como usar o docker ja que nao vamos usar ele
Resolve #341 