### PR TITLE
erroDeCaminhoPrivacidade

### DIFF
--- a/Relatórios de bug e erro/erroDeCaminhoPrivacidade.txt
+++ b/Relatórios de bug e erro/erroDeCaminhoPrivacidade.txt
@@ -1,0 +1,4 @@
+Nome: Gustavo Esteque Dubovicki
+Data: 13/11/2025 
+Área do bug: Front-end
+Descrição do bug/erro: Ao clicar no botão que redicionaria à tela de Privacidade, o site não leva a tal tela.


### PR DESCRIPTION
Nome: Gustavo Esteque Dubovicki
Data: 13/11/2025
Área do bug: Front-end
Descrição do bug/erro: Ao clicar no botão que redicionaria à tela de Privacidade, o site não leva a tal tela.
#429 